### PR TITLE
Improve exception handling

### DIFF
--- a/src/main/java/ch/unibas/dmi/dbis/chronos/agent/AbstractChronosAgent.java
+++ b/src/main/java/ch/unibas/dmi/dbis/chronos/agent/AbstractChronosAgent.java
@@ -143,6 +143,12 @@ public abstract class AbstractChronosAgent extends Thread {
             // TODO: this method needs refactoring!
             mainLoop:
             while ( running ) {
+                if ( Thread.currentThread().isInterrupted() ) {
+                    log.debug( "Ending mainLoop. Reason: Interrupt flag is set." );
+                    this.running = false;
+                    break mainLoop;
+                }
+
                 // (1) Requesting new job
                 final ChronosJob job;
                 try {

--- a/src/main/java/ch/unibas/dmi/dbis/chronos/agent/ChronosException.java
+++ b/src/main/java/ch/unibas/dmi/dbis/chronos/agent/ChronosException.java
@@ -1,14 +1,14 @@
 package ch.unibas.dmi.dbis.chronos.agent;
 
 
-public class ExecutionException extends Exception {
+public class ChronosException extends Exception {
 
     /**
      * Constructs a new exception with the specified detail message. The cause is not initialized, and may subsequently be initialized by a call to {@link #initCause}.
      *
      * @param message the detail message. The detail message is saved for later retrieval by the {@link #getMessage()} method.
      */
-    public ExecutionException( String message ) {
+    public ChronosException( String message ) {
         super( message );
     }
 
@@ -21,7 +21,7 @@ public class ExecutionException extends Exception {
      * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method). (A "null" value is permitted, and indicates that the cause is nonexistent or unknown.)
      * @since 1.4
      */
-    public ExecutionException( String message, Throwable cause ) {
+    public ChronosException( String message, Throwable cause ) {
         super( message, cause );
     }
 
@@ -33,7 +33,7 @@ public class ExecutionException extends Exception {
      * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method). (A "null" value is permitted, and indicates that the cause is nonexistent or unknown.)
      * @since 1.4
      */
-    public ExecutionException( Throwable cause ) {
+    public ChronosException( Throwable cause ) {
         super( cause );
     }
 }

--- a/src/main/java/ch/unibas/dmi/dbis/chronos/agent/ChronosException.java
+++ b/src/main/java/ch/unibas/dmi/dbis/chronos/agent/ChronosException.java
@@ -19,7 +19,6 @@ public class ChronosException extends Exception {
      *
      * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method). (A "null" value is permitted, and indicates that the cause is nonexistent or unknown.)
-     * @since 1.4
      */
     public ChronosException( String message, Throwable cause ) {
         super( message, cause );
@@ -31,7 +30,6 @@ public class ChronosException extends Exception {
      * This constructor is useful for exceptions that are little more than wrappers for other throwables (for example, {@link java.security.PrivilegedActionException}).
      *
      * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method). (A "null" value is permitted, and indicates that the cause is nonexistent or unknown.)
-     * @since 1.4
      */
     public ChronosException( Throwable cause ) {
         super( cause );

--- a/src/main/java/ch/unibas/dmi/dbis/chronos/agent/ExecutionException.java
+++ b/src/main/java/ch/unibas/dmi/dbis/chronos/agent/ExecutionException.java
@@ -19,7 +19,6 @@ public class ExecutionException extends Exception {
      *
      * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method). (A "null" value is permitted, and indicates that the cause is nonexistent or unknown.)
-     * @since 1.4
      */
     public ExecutionException( String message, Throwable cause ) {
         super( message, cause );
@@ -31,7 +30,6 @@ public class ExecutionException extends Exception {
      * This constructor is useful for exceptions that are little more than wrappers for other throwables (for example, {@link java.security.PrivilegedActionException}).
      *
      * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method). (A "null" value is permitted, and indicates that the cause is nonexistent or unknown.)
-     * @since 1.4
      */
     public ExecutionException( Throwable cause ) {
         super( cause );


### PR DESCRIPTION
New exception handling. This commits attempts to solve issue #1.

* ChronosException is used if the Chronos Control service was reachable but the request was not successful. For example, Chronos Control returned HTTP 600.

* IOException is used if there are problems regarding the connection to the Chronos Control service. For example, in the presence of network issues.

* InterruptedException is now better handled in a sense that interrupting the Chronos Agent Thread now leads to its termination. Before termination it tries to mark the currently processed job as ABORTED.

* Some public methods got Javadoc.

* Minor cosmetic changes.